### PR TITLE
Update onnx upper bound to allow 1.21.0 (CVE-2026-27489)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ evaluate
 joblib
 ninja
 numpy<=2.1.3
-onnx>=1.16.0,<=1.19.0
+onnx>=1.16.0,<=1.21.0
 onnxscript
 onnxslim>=0.1.84
 pandas


### PR DESCRIPTION
## Summary

Relax the onnx version constraint in `requirements.txt` from `<=1.19.0` to `<=1.21.0` to allow installation of onnx 1.21.0, which fixes [CVE-2026-27489](https://github.com/advisories/GHSA-3r9x-f23j-gc73) (CVSS 8.7 HIGH — path traversal via symlink in external data loading).

## Changes

```diff
-onnx>=1.16.0,<=1.19.0
+onnx>=1.16.0,<=1.21.0
```

## Context

Downstream projects that depend on Quark inherit this constraint and are currently unable to upgrade to the patched onnx version.

Fixes #28