### PR TITLE
Fix file2file int4/uint4 packing to match advertised pack_method="reorder"

### DIFF
--- a/quark/torch/quantization/file2file_quantization.py
+++ b/quark/torch/quantization/file2file_quantization.py
@@ -637,7 +637,7 @@ def _quantize_and_save_safetensor_shard(
                 qscheme.value,
             )
             pack_method = create_pack_method(qscheme=qscheme.value, dtype=dtype.value)
-            quantized_tensors[tensor_name] = pack_method.pack(quantized_weight, False)
+            quantized_tensors[tensor_name] = pack_method.pack(quantized_weight, reorder=True)
 
             if getattr(weight_config, "scale_format", None) == "e8m0":
                 # Convert scale to e8m0 format (MXFP4 standard)


### PR DESCRIPTION
## Summary

`_quantize_and_save_safetensor_shard` (the worker behind `ModelQuantizer.direct_quantize_checkpoint`) packs `int4`/`uint4` weights with the **linear** nibble layout, while the same function unconditionally writes `pack_method="reorder"` (AWQ-interleaved) into the exported `config.json`. Loaders that respect that field — vLLM's `compressed_tensors_w4a16` and Quark's own `qparamslinear` — call the AWQ-interleaved unpacker on linearly-packed bytes and silently scramble every nibble. Models load cleanly and emit garbage.

This PR flips the one offending positional arg to `reorder=True`, making the bytes match the metadata.


## Why this is safe

- **Only `Pack_4_bits` actually honors `reorder`.** Every other `Pack` class in `quark/torch/utils/pack.py` (`Pack_2/3/8_bits`, `Pack_mxfp4/6`, `Pack_fp4/6`) accepts the kwarg but ignores it. So FP8, MXFP4/6, FP4/6, INT8/UINT8, INT2/INT3 weights produced by file2file are bit-for-bit unchanged.
- **The file2file path was the lone outlier.** Every other Quark export entry point already defaults to `reorder=True`: `export/api.py::export_safetensors`, `ExporterConfig.pack_method`, `native_model_info_builder.py`, `qparamslinear.py`, `ModelQuantizer.export_*`, and `experimental/cli/torch_llm_ptq.py`.
- **The exported config already promises `pack_method="reorder"`** (`file2file_quantization.py:863`). This PR makes the bytes match the metadata; the reverse fix would diverge from every other Quark export and break the documented `pack_method` schema in `export/api.py:138-140`.
- **Existing unit tests already cover both layouts.** `test/test_for_torch/test_pack_unpack_tensor.py::test_pack_unpack` round-trips both `reorder=True` and `reorder=False` for `int4`/`uint4`/`int8`/`uint8`. CI passes unchanged.

## Empirical evidence

Kimi-K2.5 quantized via `quantize_quark.py --quant_scheme w_int4_per_group_sym --file2file_quantization`, evaluated on gsm8k (100 samples) under vLLM's `compressed_tensors_w4a16`:

| Bytes from… | gsm8k |
|---|---|
| current `release/0.11` | **0 / 100** (garbage) |
| same bytes manually repacked with `reorder=True` (i.e. what this PR produces) | **94 / 100** |

The weights themselves were correct — only the on-disk nibble order was wrong.

## Migration impact

This is a bug fix that ships a byte-layout change. Pre-existing `int4`/`uint4` checkpoints from `direct_quantize_checkpoint` were already being mis-loaded by `pack_method`-aware loaders; after this PR they continue to load without error but still produce garbage until regenerated. 


## Notes for reviewers

- I targeted `release/0.11` because that's where I observed the bug, but `release/0.10` looks identical and the same fix should apply.