### PR TITLE
Support Python 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
     'Intended Audience :: Education',
     'Intended Audience :: Science/Research',
     'Operating System :: OS Independent',
+    'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',
@@ -37,7 +38,7 @@ readme = "README.md"
 # ``setup.py::_load_requires_python_spec()`` to gate cp-wheel vs universal
 # fallback. Keep in sync with ``[project].classifiers`` below and the install
 # docs (``docs/source/install.rst``, ``CONTRIBUTING.md``).
-requires-python = ">=3.11,<3.14"
+requires-python = ">=3.10,<3.14"
 
 [project.urls]
 documentation = "https://quark.docs.amd.com"

--- a/quark/contrib/llm_eval/experiment_report.py
+++ b/quark/contrib/llm_eval/experiment_report.py
@@ -7,7 +7,9 @@ import json
 import os
 import sys
 from argparse import Namespace
-from datetime import UTC, datetime
+from datetime import datetime, timezone
+
+UTC = timezone.utc
 from typing import Any
 
 import numpy as np

--- a/quark/torch/quantization/nn/modules/quantize_conv_bn_fused.py
+++ b/quark/torch/quantization/nn/modules/quantize_conv_bn_fused.py
@@ -4,7 +4,8 @@
 #
 
 import math
-from typing import Any, Self
+from typing import Any
+from typing_extensions import Self
 
 import numpy as np
 import torch

--- a/setup.py
+++ b/setup.py
@@ -554,5 +554,5 @@ setup(
     cmdclass=cmdclass,
     install_requires=install_requires,
     # Keep in sync with ``pyproject.toml::[project].requires-python``.
-    python_requires=">=3.11,<3.14",
+    python_requires=">=3.10,<3.14",
 )


### PR DESCRIPTION
## Summary

Quark 0.12 declares `requires-python = ">=3.11,<3.14"`, but the only Python
3.11-specific features used in the codebase are two symbols that have drop-in
3.10 equivalents. This PR lowers the supported floor to Python 3.10 so Quark
installs and runs on 3.10 environments (e.g. venvs shipping a torch / serving
stack pinned to 3.10).

## Changes

- `quark/torch/quantization/nn/modules/quantize_conv_bn_fused.py`: import
  `Self` from `typing_extensions` instead of `typing` (`typing.Self` is 3.11+).
  This module is imported on the Torch quantization path via
  `quark.torch.quantization.nn.modules.__init__`, so it broke `import` on 3.10.
- `quark/contrib/llm_eval/experiment_report.py`: replace `datetime.UTC` (3.11+)
  with `datetime.timezone.utc`.
- `pyproject.toml` / `setup.py`: lower `requires-python` / `python_requires`
  floor from 3.11 to 3.10 and add the `Python :: 3.10` classifier.

## Verification

On Python 3.10.12:
- Before: `from quark.torch.quantization.nn.modules import QuantizedConvBatchNorm2d`
  raised `ImportError: cannot import name 'Self' from 'typing'`.
- After: `from quark.torch import ModelQuantizer` and the ONNX export API import
  cleanly, and the C++ kernel extension builds/loads (gfx942/gfx950).

## Test plan

- [ ] CI green on 3.10 / 3.11 / 3.12 / 3.13
- [ ] `pip install -e .` succeeds on a Python 3.10 venv
- [ ] Torch PTQ smoke on 3.10